### PR TITLE
Use the defaultAuth() method instead of withTokenAuth()

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
           tools: composer:v2
-          coverage: none
+          coverage: xdebug
 
       - name: Setup problem matchers
         run: |
@@ -52,4 +52,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --coverage

--- a/src/Connectors/PlausibleConnector.php
+++ b/src/Connectors/PlausibleConnector.php
@@ -4,6 +4,7 @@ namespace NjoguAmos\Plausible\Connectors;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Traits\HasCaching;
+use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
@@ -13,9 +14,16 @@ class PlausibleConnector extends Connector implements Cacheable
 {
     use HasCaching;
 
+    protected ?string $token;
+
     public function __construct()
     {
-        $this->withTokenAuth(token: config(key: 'plausible.api_key'));
+        $this->token = config(key: 'plausible.api_key');
+    }
+
+    protected function defaultAuth(): TokenAuthenticator
+    {
+        return new TokenAuthenticator($this->token);
     }
 
     public function resolveBaseUrl(): string


### PR DESCRIPTION
Fix `Call to deprecated method withTokenAuth() of class Saloon\Http\Connector:`

The method will be removed in Saloon v4. 

This PR upgrades to `defaultAuth()` method  instead.